### PR TITLE
fixed script to work with standard awk

### DIFF
--- a/contrib/scripts/makegrabcsv.sh
+++ b/contrib/scripts/makegrabcsv.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-echo "grab result"|nc localhost 8888|awk '
+ebusctl grab result|awk '
 BEGIN{
   len[""]=0
   delete len[""]
+  found=0
 }
 /grab disabled/ {
   print "enable grab first!"
@@ -10,9 +11,10 @@ BEGIN{
 }
 /.+/ {
   len[substr($1,3)]=length($3)/2;
+  found=1
 }
 END {
-  if (length(len)>0)
+  if (found>0)
     print "# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates"
   for (i in len) {
     zz=substr(i,1,2)
@@ -20,22 +22,28 @@ END {
     id=substr(i,9)
     idlen=length(id)/2
     if (pbsb=="b509" && substr(id,1,2)=="0d") {
-      //register read
-      reg=strtonum("0x" substr(id,3,2))
-      reg+=strtonum("0x" substr(id,5,2))*256
+      # register read
+      reg=index("123456789abcdef",tolower(substr(id,4,1)))
+      reg+=index("123456789abcdef",tolower(substr(id,3,1)))*16
+      reg+=index("123456789abcdef",tolower(substr(id,6,1)))*256
+      reg+=index("123456789abcdef",tolower(substr(id,5,1)))*4096
       print "r,unknown" zz ",reg" reg ",,," zz "," pbsb "," substr(id,3,4) ",data,,HEX:" (len[i]-1)
     } else if (pbsb=="b509" && substr(id,1,2)=="0e") {
-      //register write
-      reg=strtonum("0x" substr(id,3,2))
-      reg+=strtonum("0x" substr(id,5,2))*256
+      # register write
+      reg=index("123456789abcdef",tolower(substr(id,4,1)))
+      reg+=index("123456789abcdef",tolower(substr(id,3,1)))*16
+      reg+=index("123456789abcdef",tolower(substr(id,6,1)))*256
+      reg+=index("123456789abcdef",tolower(substr(id,5,1)))*4096
       print "w,unknown" zz ",reg" reg ",,," zz "," pbsb "," substr(id,3,4) ",data,,HEX:" (idlen-3)
     } else if (pbsb=="b509" && substr(id,1,2)=="29") {
-      //register update
-      reg=strtonum("0x" substr(id,3,2))
-      reg+=strtonum("0x" substr(id,5,2))*256
+      # register update
+      reg=index("123456789abcdef",tolower(substr(id,4,1)))
+      reg+=index("123456789abcdef",tolower(substr(id,3,1)))*16
+      reg+=index("123456789abcdef",tolower(substr(id,6,1)))*256
+      reg+=index("123456789abcdef",tolower(substr(id,5,1)))*4096
       print "u,unknown" zz ",reg" reg ",,," zz "," pbsb "," substr(id,3,4) ",,,IGN:2,,,,data,,HEX:" (len[i]-3)
     } else if (len[i]<=1 || idlen>3) {
-      //seems to be a write
+      # seems to be a write
       if (idlen>3) idlen=3
       else if (len[i]<=1) idlen--;
       printf "w,unknown" zz ","


### PR DESCRIPTION
For some reason, I don't have GNU awk installed - so I removed the usage of array length and strtonum().
Further I'd prefer ebusctl which seems to come with every ebusd installation to avoid the dependency for 'nc'.
