### PR TITLE
Add Default-Stop to init script

### DIFF
--- a/contrib/etc/init.d/ebusd.debian
+++ b/contrib/etc/init.d/ebusd.debian
@@ -5,7 +5,7 @@
 # Required-Start:  $network $remote_fs $syslog
 # Required-Stop:   $network $remote_fs $syslog
 # Default-Start:   2 3 4 5
-# Default-Stop:
+# Default-Stop:    0 1 6
 # Short-Description: Start ebusd
 ### END INIT INFO
 


### PR DESCRIPTION
Enabling the debian init-script reports the following warning:

> update-rc.d: warning: default stop runlevel arguments (0 1 6) do not match ebusd Default-Stop values (none)

This change tells update-rc.d to stop this service on shutdown.
