### PR TITLE
Add switch to disable automated update checker.

### DIFF
--- a/src/ebusd/main.cpp
+++ b/src/ebusd/main.cpp
@@ -111,6 +111,7 @@ static struct options opt = {
   false,  // localOnly
   0,  // httpPort
   "/var/" PACKAGE "/html",  // htmlPath
+  true, // update checks
 
   PACKAGE_LOGFILE,  // logFile
   -1,  // logAreas
@@ -156,7 +157,8 @@ static const char argpdoc[] =
 #define O_LOCAL  (O_PIDFIL+1)
 #define O_HTTPPT (O_LOCAL+1)
 #define O_HTMLPA (O_HTTPPT+1)
-#define O_LOG    (O_HTMLPA+1)
+#define O_UPDATE (O_HTMLPA+1)
+#define O_LOG    (O_UPDATE+1)
 #define O_LOGARE (O_LOG+1)
 #define O_LOGLEV (O_LOGARE+1)
 #define O_RAW    (O_LOGLEV+1)
@@ -208,6 +210,7 @@ static const struct argp_option argpoptions[] = {
   {"localhost",      O_LOCAL,  NULL,    0, "Listen for command line connections on 127.0.0.1 interface only", 0 },
   {"httpport",       O_HTTPPT, "PORT",  0, "Listen for HTTP connections on PORT, 0 to disable [0]", 0 },
   {"htmlpath",       O_HTMLPA, "PATH",  0, "Path for HTML files served by HTTP port [/var/ebusd/html]", 0 },
+  {"no-update-checker",      O_UPDATE, NULL,    0, "Disable automated update checker.", 0 },
 
   {NULL,             0,        NULL,    0, "Log options:", 5 },
   {"logfile",        'l',      "FILE",  0, "Write log to FILE (only for daemon) [" PACKAGE_LOGFILE "]", 0 },
@@ -455,6 +458,9 @@ error_t parse_opt(int key, char *arg, struct argp_state *state) {
       return EINVAL;
     }
     opt->htmlPath = arg;
+    break;
+  case O_UPDATE:  // --no-update-checker
+    opt->update = false;
     break;
 
   // Log options:

--- a/src/ebusd/main.h
+++ b/src/ebusd/main.h
@@ -69,6 +69,7 @@ struct options {
   bool localOnly;  //!< listen on 127.0.0.1 interface only
   uint16_t httpPort;  //!< optional port to listen for HTTP connections, 0 to disable [0]
   const char* htmlPath;  //!< path for HTML files served by the HTTP port [/var/ebusd/html]
+  bool update; //!< disable automated update checker
 
   const char* logFile;  //!< log file name [/var/log/ebusd.log]
   int logAreas;  //!< log areas [all]

--- a/src/ebusd/mainloop.cpp
+++ b/src/ebusd/mainloop.cpp
@@ -100,7 +100,7 @@ result_t UserList::addFromFile(const string& filename, unsigned int lineNo, map<
 MainLoop::MainLoop(const struct options& opt, Device *device, MessageMap* messages)
   : Thread(), m_device(device), m_reconnectCount(0), m_userList(opt.accessLevel), m_messages(messages),
     m_address(opt.address), m_scanConfig(opt.scanConfig), m_initialScan(opt.readOnly ? ESC : opt.initialScan),
-    m_polling(opt.pollInterval > 0), m_enableHex(opt.enableHex), m_shutdown(false) {
+    m_polling(opt.pollInterval > 0), m_enableHex(opt.enableHex), m_update(opt.update), m_shutdown(false) {
   // open Device
   result_t result = m_device->open();
   if (result != RESULT_OK) {
@@ -298,7 +298,7 @@ void MainLoop::run() {
           logError(lf_main, "conditions require a poll interval > 0");
         }
       }
-      if (!m_shutdown && now > nextCheckRun) {
+      if (!m_shutdown && m_update && now > nextCheckRun) {
         TCPClient client;
         TCPSocket* socket = client.connect("ebusd.eu", 80);
         if (socket) {

--- a/src/ebusd/mainloop.h
+++ b/src/ebusd/mainloop.h
@@ -373,6 +373,9 @@ class MainLoop : public Thread, DeviceListener {
   /** whether to enable the hex command. */
   const bool m_enableHex;
 
+  /** whether to disable the update checker. */
+  const bool m_update;
+
   /** set to true to shutdown. */
   bool m_shutdown;
 


### PR DESCRIPTION
The command line switch **--no-update-checker** will disable the update checker routine to avoid outside communications.

