### PR TITLE
! Fixed setsockopt call for timeout

### DIFF
--- a/src/lib/utils/tcpsocket.h
+++ b/src/lib/utils/tcpsocket.h
@@ -108,8 +108,8 @@ class TCPSocket {
     struct timeval t;
     t.tv_usec = 0;
     t.tv_sec = timeout;
-    setsockopt(m_sfd, SO_RCVTIMEO, SO_REUSEADDR, &t, sizeof(t));
-    setsockopt(m_sfd, SO_SNDTIMEO, SO_REUSEADDR, &t, sizeof(t));
+    setsockopt(m_sfd, SOL_SOCKET, SO_RCVTIMEO, &t, sizeof(t));
+    setsockopt(m_sfd, SOL_SOCKET, SO_SNDTIMEO, &t, sizeof(t));
   }
 
  private:


### PR DESCRIPTION
In my opinion the setsockopt call statement for the recv and send timeout in TCPSocket::setTimeout() seems to be wrong! 