### PR TITLE
Smaller docker runtime image

### DIFF
--- a/contrib/docker/runtime/Dockerfile
+++ b/contrib/docker/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y \
     logrotate libmosquitto1 \


### PR DESCRIPTION
Creates smaller runtime image- 123mb vs. 185mb in my test