### PR TITLE
added info to program version if MQTT is build-in

### DIFF
--- a/src/ebusd/main.cpp
+++ b/src/ebusd/main.cpp
@@ -36,9 +36,9 @@
 
 /** the version string of the program. */
 #ifdef HAVE_MQTT
-  const char *argp_program_version = "" PACKAGE_STRING "." REVISION " [MQTT]";
+const char *argp_program_version = "" PACKAGE_STRING "." REVISION " [MQTT]";
 #else
-  const char *argp_program_version = "" PACKAGE_STRING "." REVISION "";
+const char *argp_program_version = "" PACKAGE_STRING "." REVISION "";
 #endif
 
 /** the report bugs to address of the program. */

--- a/src/ebusd/main.cpp
+++ b/src/ebusd/main.cpp
@@ -35,7 +35,11 @@
 
 
 /** the version string of the program. */
-const char *argp_program_version = "" PACKAGE_STRING "." REVISION "";
+#ifdef HAVE_MQTT
+  const char *argp_program_version = "" PACKAGE_STRING "." REVISION " [MQTT]";
+#else
+  const char *argp_program_version = "" PACKAGE_STRING "." REVISION "";
+#endif
 
 /** the report bugs to address of the program. */
 const char *argp_program_bug_address = "" PACKAGE_BUGREPORT "";
@@ -1145,7 +1149,7 @@ int main(int argc, char* argv[]) {
 
   s_messageMap = new MessageMap(string(opt.configPath)+"/", opt.checkConfig);
   if (opt.checkConfig) {
-    logNotice(lf_main, PACKAGE_STRING "." REVISION " performing configuration check...");
+    logNotice(lf_main, "%s performing configuration check...", argp_program_version);
 
     result_t result = loadConfigFiles(s_messageMap, true, opt.scanConfig && arg_index < argc);
     executeInstructions(s_messageMap, true);
@@ -1196,7 +1200,8 @@ int main(int argc, char* argv[]) {
   signal(SIGINT, signalHandler);
   signal(SIGTERM, signalHandler);
 
-  logNotice(lf_main, PACKAGE_STRING "." REVISION " started%s",
+  logNotice(lf_main, "%s started%s",
+      argp_program_version,
       opt.scanConfig ? opt.initialScan == ESC ? " with auto scan"
       : opt.initialScan == BROADCAST ? " with broadcast scan" : opt.initialScan == SYN ? " with full scan"
       : " with single scan" : "");

--- a/src/ebusd/mainloop.cpp
+++ b/src/ebusd/mainloop.cpp
@@ -1503,7 +1503,7 @@ result_t MainLoop::executeInfo(const vector<string>& args, const string& user, o
                 " Report information about the daemon, the configuration, and seen devices.";
     return RESULT_OK;
   }
-  *ostream << "version: " << PACKAGE_STRING "." REVISION "\n";
+  *ostream << "version: " << argp_program_version "\n";
   if (!m_updateCheck.empty()) {
     *ostream << "update check: " << m_updateCheck << "\n";
   }

--- a/src/ebusd/mainloop.cpp
+++ b/src/ebusd/mainloop.cpp
@@ -1503,7 +1503,7 @@ result_t MainLoop::executeInfo(const vector<string>& args, const string& user, o
                 " Report information about the daemon, the configuration, and seen devices.";
     return RESULT_OK;
   }
-  *ostream << "version: " << argp_program_version "\n";
+  *ostream << "version: " << argp_program_version << "\n";
   if (!m_updateCheck.empty()) {
     *ostream << "update check: " << m_updateCheck << "\n";
   }

--- a/src/ebusd/mqtthandler.cpp
+++ b/src/ebusd/mqtthandler.cpp
@@ -531,7 +531,7 @@ void MqttHandler::run() {
   time(&now);
   start = lastTaskRun = now;
   const string sep = (g_publishFormat & OF_JSON) ? "\"" : "";
-  publishTopic(m_globalTopic+"version", sep + (PACKAGE_STRING "." REVISION) + sep, true);
+  publishTopic(m_globalTopic+"version", sep + (argp_program_version) + sep, true);
   publishTopic(m_globalTopic+"running", "true", true);
   publishTopic(signalTopic, "false");
   mosquitto_message_callback_set(m_mosquitto, on_message);


### PR DESCRIPTION
I missed the information if MQTT-support is build-in into the ebusd-binary.
So a added this information to the version string wich is used in every output now.