### PR TITLE
try to reconnect to a mqtt-server wich is non-reachable at startup

### DIFF
--- a/src/ebusd/mqtthandler.cpp
+++ b/src/ebusd/mqtthandler.cpp
@@ -381,11 +381,16 @@ MqttHandler::MqttHandler(UserInfo* userInfo, BusHandler* busHandler, MessageMap*
 #else
     ret = mosquitto_connect(m_mosquitto, g_host, g_port, 60, true);
 #endif
+/* J0EK3R: user configured ebusd to connect to mqtt-server so do it in any case!
+           If run as microservice (docker-container) it is possible that ebusd starts
+           before mqtt-server (docker-container too) - so retry to connect!
     if (ret == MOSQ_ERR_INVAL) {
       logOtherError("mqtt", "unable to connect (invalid parameters)");
       mosquitto_destroy(m_mosquitto);
       m_mosquitto = NULL;
-    } else if (ret != MOSQ_ERR_SUCCESS) {
+    } else 
+*/
+    if (ret != MOSQ_ERR_SUCCESS) {
       m_connected = false;
       char* error;
       if (ret != MOSQ_ERR_ERRNO) {


### PR DESCRIPTION
If the user configured ebusd to connect to a mqtt-server it should try and retry to connect in any case!
Even if the mqtt-server isn't reachable at ebusds startup.
If ebusd is run as a microservice (i.e. as docker-container) on a NAS it is possible that after rebooting the NAS ebusd starts before the mqtt-server (wich is also running as docker-container on the same NAS) - so it is mandatory to retry to connect later!

Till now, ebusd was able to reconnect an established connection. That is well-working!
I changed the code after the first attempt to connect to the configured mqtt-server not to destroy the mosquitto-instance but to retry to connect later with the current well-working mechanism.