### PR TITLE
Fix handling of the log open error

### DIFF
--- a/src/lib/utils/log.cpp
+++ b/src/lib/utils/log.cpp
@@ -134,6 +134,7 @@ LogLevel getFacilityLogLevel(LogFacility facility) {
 bool setLogFile(const char* filename) {
   FILE* newFile = fopen(filename, "a");
   if (newFile == nullptr) {
+    s_logFile = nullptr;
     return false;
   }
   closeLogFile();


### PR DESCRIPTION
Hi John,

I been able to identify typical heisenbug :) Ebusd was working perfectly for me if running in foreground mode but was completely messing communication (up to the need of restarting heater) if running as a background service. 
After all i been able to identify the source of the issue - it happens only if it is not possible to open log file (in my case it was permission issue). Going forward i found that in log.cpp s_logFile is set by default to `stdout`  (which is probably fd 1) and is not set to 0 if open fails. As there is no stdout in daemon mode it probably starts logging to the first open FD, which will be serial. This causing such funny behavior. 