### PR TITLE
Gcc 10 warning fixes

### DIFF
--- a/src/lib/ebus/datatype.cpp
+++ b/src/lib/ebus/datatype.cpp
@@ -351,7 +351,7 @@ result_t DateTimeDataType::readSymbols(size_t offset, size_t length, const Symbo
         }
         *output << dec << setfill('0') << setw(2) << static_cast<unsigned>(d) << "."
                 << setw(2) << static_cast<unsigned>(m) << "." << static_cast<unsigned>(y + 1900);
-        m = (int)(minutes%(24*60));
+        m = static_cast<int>(minutes%(24*60));
         d = m/60;
         *output << " " << setw(2) << dec << setfill('0') << static_cast<unsigned>(d);
         m -= d*60;

--- a/src/lib/ebus/datatype.cpp
+++ b/src/lib/ebus/datatype.cpp
@@ -68,8 +68,7 @@ bool DataType::dump(OutputFormat outputFormat, size_t length, bool appendDivisor
 }
 
 
-result_t StringDataType::readRawValue(size_t offset, size_t length, const SymbolString& input,
-                                      unsigned int* value) const {
+result_t StringDataType::readRawValue(size_t, size_t, const SymbolString&, unsigned int*) const {
   return RESULT_EMPTY;
 }
 
@@ -204,8 +203,7 @@ result_t StringDataType::writeSymbols(size_t offset, size_t length, istringstrea
 }
 
 
-result_t DateTimeDataType::readRawValue(size_t offset, size_t length, const SymbolString& input,
-                                        unsigned int* value) const {
+result_t DateTimeDataType::readRawValue(size_t, size_t, const SymbolString&, unsigned int*) const {
   return RESULT_EMPTY;
 }
 

--- a/src/tools/ebuspicloader.cpp
+++ b/src/tools/ebuspicloader.cpp
@@ -904,7 +904,7 @@ int main(int argc, char* argv[]) {
       printFileChecksum();
       exit(EXIT_SUCCESS);
     } else {
-      argp_help(&aargp, stderr, ARGP_HELP_STD_ERR, "ebuspicloader");
+      argp_help(&aargp, stderr, ARGP_HELP_STD_ERR, const_cast<char*>("ebuspicloader"));
       exit(EXIT_FAILURE);
     }
   }


### PR DESCRIPTION
There in one other warning in https://github.com/john30/ebusd/blob/master/src/ebusd/bushandler.cpp#L440

```
/home/kratz00/coding/ebus/ebusd/src/ebusd/bushandler.cpp: In member function ‘ebusd::result_t ebusd::BusHandler::handleSymbol()’:
/home/kratz00/coding/ebus/ebusd/src/ebusd/bushandler.cpp:440:13: warning: this statement may fall through [-Wimplicit-fallthrough=]
  440 |     timeout = SYN_TIMEOUT;
/home/kratz00/coding/ebus/ebusd/src/ebusd/bushandler.cpp:441:3: note: here
  441 |   case bs_ready:
      |   ^~~~
```
Is this intentionally or is there a *break;* missing?