### PR TITLE
fix compiler warning: this statement may fall through

### DIFF
--- a/src/ebusd/bushandler.cpp
+++ b/src/ebusd/bushandler.cpp
@@ -438,6 +438,7 @@ result_t BusHandler::handleSymbol() {
 
   case bs_skip:
     timeout = SYN_TIMEOUT;
+    [[fallthrough]];
   case bs_ready:
     if (m_currentRequest != nullptr) {
       setState(bs_ready, RESULT_ERR_TIMEOUT);  // just to be sure an old BusRequest is cleaned up


### PR DESCRIPTION
According to @john30 this is by intention (see https://github.com/john30/ebusd/pull/409#issuecomment-817264951).
So I made it obvious and silenced the compiler warning.