### PR TITLE
Make MQTT JSON Verbose with Units, Comments, Attrs

### DIFF
--- a/src/ebusd/mqtthandler.cpp
+++ b/src/ebusd/mqtthandler.cpp
@@ -186,7 +186,7 @@ static error_t mqtt_parse_opt(int key, char *arg, struct argp_state *state) {
     break;
 
   case O_JSON:  // --mqttjson
-    g_publishFormat |= OF_JSON|OF_NAMES;
+    g_publishFormat |= OF_JSON|OF_NAMES|OF_UNITS|OF_COMMENTS|OF_ALL_ATTRS;
     break;
 
 #if (LIBMOSQUITTO_VERSION_NUMBER >= 1003001)
@@ -903,6 +903,7 @@ void MqttHandler::publishMessage(const Message* message, ostringstream* updates,
           getResultCode(result));
       return;
     }
+    message->appendAttributes(outputFormat, updates)
     if (json) {
       *updates << "}";
     }
@@ -924,6 +925,7 @@ void MqttHandler::publishMessage(const Message* message, ostringstream* updates,
           name.c_str(), getResultCode(result));
       return;
     }
+    message->appendAttributes(outputFormat, updates);
     publishTopic(getTopic(message, "", name), updates->str());
     updates->str("");
     updates->clear();


### PR DESCRIPTION
This makes the JSON Output more Verbose by changing the Option
```
case O_JSON:  // --mqttjson
    g_publishFormat |= OF_JSON|OF_NAMES|OF_UNITS|OF_COMMENTS|OF_ALL_ATTRS;
```

The resulting output enables users to understand messages without consulting the config files.

Example:
for previously ambiguous messages, users would have to go through the config files, find message definitions, understand their structure and apply domain knowledge within the comments of the config files to understand a `ebusd/hmu/Status01` message such as the following 
```
{
    "0": {
        "name": "temp1",
        "value": 34
    },
    "1": {
        "name": "temp1",
        "value": 32
    },
    "2": {
        "name": "temp2",
        "value": null
    },
   …
```

the proposed Changes would add the config's comments, units and attributes to the output.for the given example above  by adding
`    "comment": "Vorlauftemperatur/Rücklauftemperatur/Aussentemperatur/WW Temperatur/Speichertemperatur/Pumpenstatus"
`

an added benefit might be to motivate editors of the config files to be more explicit in their message definitions, adding Units and Comments to the [Field definition](https://github.com/john30/ebusd/wiki/4.1.-Message-definition#field-definition) resulting in very readable output messages such as:

```
"0": {
        "name": "temp1",
        "value": 30.5,
        "unit": "°C",
        "comment": "Vorlauftemperatur"
    }, 
```