### PR TITLE
Re-added target for ebusfeed to both automake & cmake

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ebusctl_SOURCES ebusctl.cpp)
 set(ebuspicloader_SOURCES ebuspicloader.cpp intelhex/intelhexclass.cpp)
+set(ebusfeed_SOURCES ebusfeed.cpp)
 
 include_directories(../lib/ebus)
 include_directories(../lib/utils)
@@ -7,7 +8,9 @@ include_directories(intelhex)
 
 add_executable(ebusctl ${ebusctl_SOURCES})
 add_executable(ebuspicloader ${ebuspicloader_SOURCES})
+add_executable(ebusfeed ${ebuspicloader_SOURCES})
 target_link_libraries(ebusctl utils ebus ${LIB_ARGP} ${ebusctl_LIBS})
 target_link_libraries(ebuspicloader ${LIB_ARGP})
+target_link_libraries(ebusfeed ${LIB_ARGP})
 
-install(TARGETS ebusctl ebuspicloader EXPORT ebusd DESTINATION usr/bin)
+install(TARGETS ebusctl ebuspicloader ebusfeed EXPORT ebusd DESTINATION usr/bin)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(intelhex)
 
 add_executable(ebusctl ${ebusctl_SOURCES})
 add_executable(ebuspicloader ${ebuspicloader_SOURCES})
-add_executable(ebusfeed ${ebuspicloader_SOURCES})
+add_executable(ebusfeed ${ebusfeed_SOURCES })
 target_link_libraries(ebusctl utils ebus ${LIB_ARGP} ${ebusctl_LIBS})
 target_link_libraries(ebuspicloader ${LIB_ARGP})
 target_link_libraries(ebusfeed ${LIB_ARGP})

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ebusctl_SOURCES ebusctl.cpp)
 set(ebuspicloader_SOURCES ebuspicloader.cpp intelhex/intelhexclass.cpp)
 set(ebusfeed_SOURCES ebusfeed.cpp)
+set(ebusfeed_LIBS ${ebusfeed_LIBS} ebus)
 
 include_directories(../lib/ebus)
 include_directories(../lib/utils)
@@ -8,9 +9,9 @@ include_directories(intelhex)
 
 add_executable(ebusctl ${ebusctl_SOURCES})
 add_executable(ebuspicloader ${ebuspicloader_SOURCES})
-add_executable(ebusfeed ${ebusfeed_SOURCES })
+add_executable(ebusfeed ${ebusfeed_SOURCES})
 target_link_libraries(ebusctl utils ebus ${LIB_ARGP} ${ebusctl_LIBS})
 target_link_libraries(ebuspicloader ${LIB_ARGP})
-target_link_libraries(ebusfeed ${LIB_ARGP})
+target_link_libraries(ebusfeed ${LIB_ARGP} ${ebusfeed_LIBS})
 
 install(TARGETS ebusctl ebuspicloader ebusfeed EXPORT ebusd DESTINATION usr/bin)

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -2,12 +2,16 @@ AM_CXXFLAGS = -I$(top_srcdir)/src \
 	      -isystem$(top_srcdir)
 
 bin_PROGRAMS = ebusctl \
-	       ebuspicloader
+	       ebuspicloader \
+               ebusfeed
 
 ebusctl_SOURCES = ebusctl.cpp
 ebusctl_LDADD = ../lib/utils/libutils.a
 
 ebuspicloader_SOURCES = ebuspicloader.cpp intelhex/intelhexclass.cpp
+
+ebusfeed_SOURCES = ebusfeed.cpp
+ebusfeed_LDADD = ../lib/ebus/libebus.a
 
 distclean-local:
 	-rm -f Makefile.in


### PR DESCRIPTION
Now builds ebusfeed, not sure why it was not build, it's in the docs but not available in the binary release, nor being built when building from source. It's quite a useful tool for creating config csv files.