### PR TITLE
Update ebusd.service

### DIFF
--- a/contrib/debian/init.d/ebusd
+++ b/contrib/debian/init.d/ebusd
@@ -10,7 +10,7 @@
 ### END INIT INFO
 
 DAEMON=/usr/bin/ebusd
-PIDFILE_PREFIX=/var/run/ebusd
+PIDFILE_PREFIX=/run/ebusd
 PIDFILE_SUFFIX=.pid
 
 if test -f /lib/lsb/init-functions; then

--- a/contrib/debian/systemd/ebusd.service
+++ b/contrib/debian/systemd/ebusd.service
@@ -7,7 +7,7 @@ ConditionPathExists=/var/log
 Type=forking
 Restart=always
 RestartSec=30
-PIDFile=/var/run/ebusd.pid
+PIDFile=/run/ebusd.pid
 EnvironmentFile=-/etc/default/ebusd
 ExecStart=/usr/bin/ebusd $EBUSD_OPTS
 


### PR DESCRIPTION
eliminating the warning during booting the system: 
dmesg | grep ebus

systemd[1]: /etc/systemd/system/ebusd.service:10: PIDFile= references a path below legacy directory /var/run/, updating /var/run/ebusd.pid → /run/ebusd.pid; please update the unit file accordingly.