### PR TITLE
add "sensor" to filter

### DIFF
--- a/contrib/etc/ebusd/mqtt-hassio.cfg
+++ b/contrib/etc/ebusd/mqtt-hassio.cfg
@@ -105,7 +105,7 @@ filter-seen = 5
 #filter-non-circuit =
 # include only messages having the specified name (partial match, alternatives and wildcard supported).
 # HA integration: filter to some useful names for monitoring the heating circuit
-filter-name = status|temp|yield|count|energy|power|runtime|hours|starts|mode|curve|^load$|^party$
+filter-name = status|temp|yield|count|energy|power|runtime|hours|starts|mode|curve|^load$|^party$|sensor
 # exclude messages having the specified name (partial match, alternatives and wildcard supported).
 #filter-non-name =
 # include only messages having the specified level (partial match, alternatives and wildcard supported).


### PR DESCRIPTION
To add sensors from e.g. vr_70 it's necessary to add "sensor" to filter-name property.
![2022-03-09 09_25_39-MQTT Explorer](https://user-images.githubusercontent.com/514609/157402126-69a75e2b-abab-4a6c-a26c-0492bdb999e0.png)

