### PR TITLE
Shutdown on failed initial scan

### DIFF
--- a/src/ebusd/mainloop.cpp
+++ b/src/ebusd/mainloop.cpp
@@ -291,6 +291,7 @@ void MainLoop::run() {
           }
           if (result != RESULT_OK) {
             logError(lf_main, "initial scan failed: %s", getResultCode(result));
+            m_shutdown = true;
           }
           if (result != RESULT_ERR_NO_SIGNAL) {
             reload = false;


### PR DESCRIPTION
When the initial scan fails, the daemon will not serve incoming requests.
Exiting and giving it chance to restart (by systemd) and rescan fixes the problem