### PR TITLE
fix compiler warning: deprecated std::binary_function

### DIFF
--- a/src/lib/ebus/message.h
+++ b/src/lib/ebus/message.h
@@ -25,7 +25,6 @@
 #include <deque>
 #include <map>
 #include <queue>
-#include <functional>
 #include "lib/ebus/data.h"
 #include "lib/ebus/result.h"
 #include "lib/ebus/symbol.h"
@@ -800,7 +799,7 @@ class ChainedMessage : public Message {
 /**
  * A function that compares the weighted poll priority of two @a Message instances.
  */
-struct compareMessagePriority : binary_function<Message*, Message*, bool> {
+struct compareMessagePriority {
   /**
    * Compare the weighted poll priority of the two @a Message instances.
    * @param x the first @a Message.


### PR DESCRIPTION
*std::binary_function* is deprecated in C++11 and will be removed in C++17 (https://en.cppreference.com/w/cpp/utility/functional/binary_function)

I saw the warning with  g++ 12.1.0 (GCC):

```
/home/kratz00/coding/ebus/ebusd/src/lib/ebus/message.h:803:33: warning: 'template<class _Arg1, class _Arg2, class _Result> struct std::binary_function' is deprecated [-Wdeprecated-declarations]
  803 | struct compareMessagePriority : binary_function<Message*, Message*, bool> {
```

