### PR TITLE
Fix compilation on Arch Linux.

### DIFF
--- a/src/lib/knx/knxnet.h
+++ b/src/lib/knx/knxnet.h
@@ -34,6 +34,7 @@
 #include <endian.h>
 #include <string>
 #include <cstdio>
+#include <ctime>
 #include "lib/knx/knx.h"
 
 namespace ebusd {


### PR DESCRIPTION
```
[  2%] Building CXX object src/lib/knx/CMakeFiles/knx.dir/knx.cpp.o
In file included from /home/kratz00/coding/ebus/ebusd/src/lib/knx/knx.cpp:30:
/home/kratz00/coding/ebus/ebusd/src/lib/knx/knxnet.h: In member function 'virtual ebusd::knx_transfer_t ebusd::KnxNetConnection::getPollData(int, uint8_t*, int*, ebusd::knx_addr_t*, ebusd::knx_addr_t*)':
/home/kratz00/coding/ebus/ebusd/src/lib/knx/knxnet.h:572:5: error: 'time' was not declared in this scope
  572 |     time(&now);
      |     ^~~~
```