### PR TITLE
Fix build on FreeBSD due to missing **environ definition

### DIFF
--- a/src/ebusd/main.cpp
+++ b/src/ebusd/main.cpp
@@ -36,6 +36,9 @@
 #include "lib/utils/httpclient.h"
 #include "ebusd/scan.h"
 
+#ifdef __FreeBSD__
+extern char **environ;
+#endif
 
 /** the version string of the program. */
 const char *argp_program_version = "" PACKAGE_STRING "." REVISION "";


### PR DESCRIPTION
This PR fixes build on FreeBSD as `**environ` is not defined in the system headers