### PR TITLE
message.h: remove std:binary_function

### DIFF
--- a/src/lib/ebus/message.h
+++ b/src/lib/ebus/message.h
@@ -58,7 +58,6 @@ namespace ebusd {
  * template class.
  */
 
-using std::binary_function;
 using std::priority_queue;
 using std::deque;
 


### PR DESCRIPTION
This PR removes   'binary_function' reference to fix error on freebsd/current 
```
 no member named 'binary_function' in namespace 'std';
```

binary_function is deprecated in C++11 and removed in  C++17. Good thing that ebusd is not using it anyway, so IMHO it is safe to remove.