### PR TITLE
Fix link for TCP client commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The main features of the daemon are:
  * log messages and problems to a log file
  * capture messages or sent/received bytes to a log file as text
  * dump received bytes to binary files for later playback/analysis
- * listen for [command line client](3.1.-TCP-client-commands) connections on a dedicated TCP port
+ * listen for [command line client](https://github.com/john30/ebusd/wiki/3.1.-TCP-client-commands) connections on a dedicated TCP port
  * provide a rudimentary HTML interface
  * format messages and data in [JSON on dedicated HTTP port](https://github.com/john30/ebusd/wiki/3.2.-HTTP-client)
  * publish received data to [MQTT topics](https://github.com/john30/ebusd/wiki/3.3.-MQTT-client) and vice versa (if authorized)


### PR DESCRIPTION
The link currently takes me to https://github.com/john30/ebusd/blob/master/3.1.-TCP-client-commands
