### PR TITLE
CMakeLists.txt: add BUILD_SHARED_LIBS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ endif()
 
 add_definitions(-fpic -Wall -Wno-unused-function -Wextra)
 
+set(BUILD_SHARED_LIBS OFF)
+
 check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_file(dirent.h HAVE_DIRENT_H)
 check_include_file(fcntl.h HAVE_FCNTL_H)


### PR DESCRIPTION
This disabled shared libs, as otherwise the compilation could fail. The installed binary files are still dynamically linked, as this affects only internal linking here.

Closes: https://github.com/john30/ebusd/issues/1132