### PR TITLE
src/{ebusd,tools}/CMakeLists.txt: remove usr path

### DIFF
--- a/src/ebusd/CMakeLists.txt
+++ b/src/ebusd/CMakeLists.txt
@@ -36,5 +36,5 @@ include_directories(../lib/utils)
 add_executable(ebusd ${ebusd_SOURCES})
 target_link_libraries(ebusd utils ebus pthread rt ${ebusd_LIBS})
 
-install(TARGETS ebusd EXPORT ebusd DESTINATION usr/bin)
+install(TARGETS ebusd EXPORT ebusd DESTINATION bin)
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -12,4 +12,4 @@ add_executable(ebuspicloader ${ebuspicloader_SOURCES})
 target_link_libraries(ebusctl utils ebus ${ebusctl_LIBS})
 target_link_libraries(ebuspicloader utils ${ebuspicloader_LIBS})
 
-install(TARGETS ebusctl ebuspicloader EXPORT ebusd DESTINATION usr/bin)
+install(TARGETS ebusctl ebuspicloader EXPORT ebusd DESTINATION bin)


### PR DESCRIPTION
/usr should not be hardcoded, as otherwise this will cause a double prefix during installation.

The correct prefix is already being handled by CMAKE_INSTALL_PREFIX.

Example:
>>> /usr/usr/bin/ebuspicloader
>>> /usr/usr/bin/ebusctl
>>> /usr/usr/bin/ebusd