### PR TITLE
Replace egrep with 'grep -E'

### DIFF
--- a/contrib/munin/ebusd_
+++ b/contrib/munin/ebusd_
@@ -57,9 +57,9 @@ if [ -n "$find2" ]; then
   fi
   result="$result\n$result2"
 fi
-sensors=`echo "$result"|sed -e 's# =.*$##' -e 's# #:#'|egrep "$match"`
+sensors=`echo "$result"|sed -e 's# =.*$##' -e 's# #:#'|grep -E "$match"`
 if [ -n "$skip" ]; then
-  sensors=`echo "$sensors"|egrep -v "$skip"`
+  sensors=`echo "$sensors"|grep -E -v "$skip"`
 fi
 sensors=`echo "$sensors"|sort -u`
 if [ "$1" = "config" ]; then

--- a/contrib/scripts/readall.sh
+++ b/contrib/scripts/readall.sh
@@ -11,7 +11,7 @@ if [ "x$1" = "x-R" ]; then
   readargs=$1
   shift
 fi
-for i in `echo "f -F circuit,name" "$@"|nc -q 1 127.0.0.1 $port|sort -u|egrep ','`; do
+for i in `echo "f -F circuit,name" "$@"|nc -q 1 127.0.0.1 $port|sort -u|grep -E ','`; do
   circuit=${i%%,*}
   name=${i##*,}
   if [ -z "$circuit" ] || [ -z "$name" ] || [ "$circuit,$name" = "scan,id" ]; then

--- a/make_debian.sh
+++ b/make_debian.sh
@@ -66,20 +66,20 @@ if [ -n "$reusebuilddir" ] || [ -z "$keepbuilddir" ]; then
 fi
 make DESTDIR="$PWD/$RELEASE" install-strip || exit 1
 extralibs=
-ldd $RELEASE/usr/bin/ebusd | egrep -q libeibclient.so.0
+ldd $RELEASE/usr/bin/ebusd | grep -E -q libeibclient.so.0
 if [ $? -eq 0 ]; then
   extralibs="$extralibs, knxd-tools"
 fi
-ldd $RELEASE/usr/bin/ebusd | egrep -q libmosquitto.so.1
+ldd $RELEASE/usr/bin/ebusd | grep -E -q libmosquitto.so.1
 if [ $? -eq 0 ]; then
   extralibs="$extralibs, libmosquitto1"
   PACKAGE="${PACKAGE}_mqtt1"
 fi
-ldd $RELEASE/usr/bin/ebusd | egrep -q libssl.so.3
+ldd $RELEASE/usr/bin/ebusd | grep -E -q libssl.so.3
 if [ $? -eq 0 ]; then
   extralibs="$extralibs, libssl3 (>= 3.0.0), ca-certificates"
 else
-  ldd $RELEASE/usr/bin/ebusd | egrep -q libssl.so.1.1
+  ldd $RELEASE/usr/bin/ebusd | grep -E -q libssl.so.1.1
   if [ $? -eq 0 ]; then
     extralibs="$extralibs, libssl1.1 (>= 1.1.0), ca-certificates"
   fi
@@ -104,7 +104,7 @@ if [ -n "$RUNTEST" ]; then
   fi
   # note: this can't run on file system base when using qemu for arm 32bit and host is 64bit due to glibc readdir() inode 32 bit values (see https://bugs.launchpad.net/qemu/+bug/1805913), thus using test end point instead:
   ("$RELEASE/usr/bin/ebusd" -f -s --configlang=tt -d /dev/null --log=all:debug --inject=stop 10fe0900040000803e/ > test.txt) || testdie "float conversion"
-  egrep "received update-read broadcast test QQ=10: 0\.25$" test.txt || testdie "float result"
+  grep -E "received update-read broadcast test QQ=10: 0\.25$" test.txt || testdie "float result"
 fi
 
 echo

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-(cd src/lib/ebus/test && make >/dev/null && ./test_filereader && ./test_data && ./test_message && ./test_symbol && echo "standard: OK!")|egrep -v "OK$"
-(cd src/lib/ebus/contrib/test && make >/dev/null && ./test_contrib && echo "contrib: OK!")|egrep -v "OK$"
+(cd src/lib/ebus/test && make >/dev/null && ./test_filereader && ./test_data && ./test_message && ./test_symbol && echo "standard: OK!")|grep -E -v "OK$"
+(cd src/lib/ebus/contrib/test && make >/dev/null && ./test_contrib && echo "contrib: OK!")|grep -E -v "OK$"

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -107,7 +107,7 @@ $ebuspicloader -f x >/dev/null 2>/dev/null
 echo -e ':100800008431542CAE3401347E1484314E01961E52\n:00000001FF' > firmware.hex
 $ebuspicloader -f firmware.hex >/dev/null
 #server:
-php -r 'echo "php is available";'|egrep 'php is available'
+php -r 'echo "php is available";'|grep -E 'php is available'
 if [ ! "$?" = 0 ]; then
   echo `date` "php is not available"
   exit 1
@@ -370,7 +370,7 @@ function send() {
 while [[ ! "$status" = 0 ]] && [[ $cnt -gt 0 ]]; do
   sleep 5
   echo `date` "check signal"
-  send state | egrep -q "signal acquired"
+  send state | grep -E -q "signal acquired"
   status=$?
   cnt=$((cnt - 1))
 done
@@ -411,7 +411,7 @@ while [ "$status" = 0 ]; do
     failed=1
     break
   fi
-  echo $output | egrep -q "still running"
+  echo $output | grep -E -q "still running"
   status=$?
   scancnt=$(( scancnt + 1 ))
 done
@@ -434,7 +434,7 @@ curl -s "http://localhost:8878/data/mc.5/installparam?poll=1&user=test&secret=te
 curl -s -T test_coverage.sh http://localhost:8878/data/
 echo `date` "commands done"
 kill $lstpid
-verify=`send info|egrep "^address 04:"`
+verify=`send info|grep -E "^address 04:"`
 expect='address 04: slave #25, scanned "MF=153;ID=BBBBB;SW=3031;HW=3031"'
 if [ "x$verify" != "x$expect" ]; then
   echo -e `date` "error unexpected result from info command:\n  expected: >$expect<\n  got: >$verify<"


### PR DESCRIPTION
The tools 'egrep' and 'fgrep' are deprecated for years and have been removed from POSIX.
"grep -E" or "grep -F" should be used as replacement.