### PR TITLE
Change default device from ttyUSB to ttyACM

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Docker image
 A multi-architecture Docker image using the config web service for retrieving the latest message configuration files is  available on the hub.
 You can use it like this:  
 > docker pull john30/ebusd  
-> docker run -it --rm --device=/dev/ttyUSB0 -p 8888 john30/ebusd
+> docker run -it --rm --device=/dev/ttyACM0 -p 8888 john30/ebusd
 
 For more details, see [Docker Readme](https://github.com/john30/ebusd/blob/master/contrib/docker/README.md).
 

--- a/contrib/archlinux/ebusd.install
+++ b/contrib/archlinux/ebusd.install
@@ -1,7 +1,7 @@
 post_install() {
   echo "Instructions:"
   echo "1. Edit /etc/conf.d/ebusd if necessary"
-  echo "   (especially if your device is not /dev/ttyUSB0)"
+  echo "   (especially if your device is not /dev/ttyACM0)"
   echo "2. Start the daemon with 'systemctl start ebusd'"
   echo "3. Check the log file /var/log/ebusd.log"
   echo "4. Make the daemon autostart with 'systemctl enable ebusd'"

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -29,16 +29,16 @@ automatically from the latest source on the git repository. Run the following co
 
 Running interactively
 ---------------------
-To run an ebusd container interactively, e.g. on serial device /dev/ttyUSB1, use the following command:
-> docker run --rm -it --device=/dev/ttyUSB1:/dev/ttyUSB0 -p 8888 john30/ebusd
+To run an ebusd container interactively, e.g. on serial device /dev/ttyACM1, use the following command:
+> docker run --rm -it --device=/dev/ttyACM1:/dev/ttyACM0 -p 8888 john30/ebusd
 
 This will show the ebusd output directly in the terminal.
 
 
 Running in background
 ---------------------
-To start an ebusd container and have it run in the background, e.g. on serial device /dev/ttyUSB1, use the following command:
-> docker run -d --name=ebusd --device=/dev/ttyUSB1:/dev/ttyUSB0 -p 8888 john30/ebusd
+To start an ebusd container and have it run in the background, e.g. on serial device /dev/ttyACM1, use the following command:
+> docker run -d --name=ebusd --device=/dev/ttyACM1:/dev/ttyACM0 -p 8888 john30/ebusd
 
 The container has the name "ebusd", so you can use that when querying docker about the container.
 
@@ -62,14 +62,14 @@ Running with MQTT broker
 ------------------------
 To start an ebusd container in the background and have it connect to your MQTT broker, use the following command while
 replacing "BROKERHOST" with your MQTT broker host name or IP address:
-> docker run -d --name=ebusd --device=/dev/ttyUSB0 -p 8888 john30/ebusd --scanconfig -d /dev/ttyUSB0 --mqttport=1883 --mqtthost=BROKERHOST
+> docker run -d --name=ebusd --device=/dev/ttyACM0 -p 8888 john30/ebusd --scanconfig -d /dev/ttyACM0 --mqttport=1883 --mqtthost=BROKERHOST
 
 
 Use of environment variables
 ----------------------------
 Instead of passing arguments (at the end of docker run) to ebusd, almost all (long) arguments can also be passed as
 environment variables with the prefix `EBUSD_`, e.g. the following line can be used instead of the last example above:
-> docker run -d --name=ebusd --device=/dev/ttyUSB0 -p 8888 -e EBUSD_SCANCONFIG= -e EBUSD_DEVICE=/dev/ttyUSB0 -e EBUSD_MQTTPORT=1883 -e EBUSD_MQTTHOST=BROKERHOST john30/ebusd
+> docker run -d --name=ebusd --device=/dev/ttyACM0 -p 8888 -e EBUSD_SCANCONFIG= -e EBUSD_DEVICE=/dev/ttyACM0 -e EBUSD_MQTTPORT=1883 -e EBUSD_MQTTHOST=BROKERHOST john30/ebusd
 
 This eases use of e.g. "docker-compose.yaml" files like [the example docker-compose file](https://github.com/john30/ebusd/blob/master/contrib/docker/docker-compose.example.yaml) also describing each available environment variable in it.
 

--- a/contrib/docker/docker-compose.example.yaml
+++ b/contrib/docker/docker-compose.example.yaml
@@ -10,13 +10,13 @@ services:
       #- 8080:8080
     devices:
       # when using an USB device, make sure to hand it in to the container like this:
-      - /dev/ttyUSB0:/dev/ttyUSB0
+      - /dev/ttyACM0:/dev/ttyACM0
     environment:
       # Device options:
 
       # Use DEV as eBUS device ("enh:DEVICE" or "enh:IP:PORT" for enhanced device, "ens:DEVICE" for enhanced high speed
       # serial device, "DEVICE" for serial device, or "[udp:]IP:PORT" for network device)
-      EBUSD_DEVICE: "/dev/ttyUSB0"
+      EBUSD_DEVICE: "/dev/ttyACM0"
       # Skip serial eBUS device test
       #EBUSD_NODEVICECHECK: ""
       # Only read from device, never write to it

--- a/make_debian.sh
+++ b/make_debian.sh
@@ -155,7 +155,7 @@ else
 fi
 echo "Instructions:"
 echo "1. Edit /etc/default/ebusd if necessary"
-echo "   (especially if your device is not /dev/ttyUSB0)"
+echo "   (especially if your device is not /dev/ttyACM0)"
 echo "2. Start the daemon with '\$start'"
 echo "3. Check the log file /var/log/ebusd.log"
 echo "4. Make the daemon autostart with '\$autostart'"

--- a/src/ebusd/main.h
+++ b/src/ebusd/main.h
@@ -37,7 +37,7 @@ namespace ebusd {
 
 /** A structure holding all program options. */
 typedef struct options {
-  const char* device;  //!< eBUS device (serial device or [udp:]ip:port) [/dev/ttyUSB0]
+  const char* device;  //!< eBUS device (serial device or [udp:]ip:port) [/dev/ttyACM0]
   bool noDeviceCheck;  //!< skip serial eBUS device test
   bool readOnly;  //!< read-only access to the device
   bool initialSend;  //!< send an initial escape symbol after connecting device

--- a/src/ebusd/main_args.cpp
+++ b/src/ebusd/main_args.cpp
@@ -38,7 +38,7 @@ namespace ebusd {
 
 /** the default program options. */
 static const options_t s_default_opt = {
-  .device = "/dev/ttyUSB0",
+  .device = "/dev/ttyACM0",
   .noDeviceCheck = false,
   .readOnly = false,
   .initialSend = false,
@@ -145,7 +145,7 @@ static const argDef argDefs[] = {
       "\"enh:\" for enhanced device, with "
       "\"IP:PORT\" for network device or "
       "\"DEVICE\" for serial device"
-      ") [/dev/ttyUSB0]"},
+      ") [/dev/ttyACM0]"},
   {"nodevicecheck",  'n',      nullptr,    0, "Skip serial eBUS device test"},
   {"readonly",       'r',      nullptr,    0, "Only read from device, never write to it"},
   {"initsend",       O_INISND, nullptr,    0, "Send an initial escape symbol after connecting device"},
@@ -239,7 +239,7 @@ static int parse_opt(int key, char *arg, const argParseOpt *parseOpt, struct opt
 
   switch (key) {
   // Device options:
-  case 'd':  // --device=/dev/ttyUSB0
+  case 'd':  // --device=/dev/ttyACM0
     if (arg == nullptr || arg[0] == 0) {
       argParseError(parseOpt, "invalid device");
       return EINVAL;

--- a/src/lib/ebus/device.h
+++ b/src/lib/ebus/device.h
@@ -100,7 +100,7 @@ class Device : public TransportListener {
 
   /**
    * Get the device name.
-   * @return the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network).
+   * @return the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network).
    */
   const char* getName() const { return m_transport->getName(); }
 

--- a/src/lib/ebus/test/test_device.cpp
+++ b/src/lib/ebus/test/test_device.cpp
@@ -24,7 +24,7 @@ using namespace std;
 using namespace ebusd;
 
 int main() {
-  Device* device = Device::create("/dev/ttyUSB20", true, false, false);
+  Device* device = Device::create("/dev/ttyACM20", true, false, false);
   if (device == nullptr) {
     cout << "unable to create device" << endl;
     return -1;

--- a/src/lib/ebus/transport.h
+++ b/src/lib/ebus/transport.h
@@ -79,7 +79,7 @@ class Transport {
  protected:
   /**
    * Construct a new instance.
-   * @param name the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network).
+   * @param name the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network).
    */
   Transport(const char* name, unsigned int latency)
   : m_name(name), m_latency(latency), m_listener(nullptr) {}
@@ -92,7 +92,7 @@ class Transport {
 
   /**
    * Get the device name.
-   * @return the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network).
+   * @return the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network).
    */
   const char* getName() const { return m_name; }
 
@@ -162,7 +162,7 @@ class Transport {
    */
   virtual result_t openInternal() = 0;  // abstract
 
-  /** the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network). */
+  /** the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network). */
   const char* m_name;
 
   /** the bus transfer latency in milliseconds. */
@@ -180,7 +180,7 @@ class FileTransport : public Transport {
  protected:
   /**
    * Construct a new instance.
-   * @param name the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network).
+   * @param name the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network).
    * @param latency the bus transfer latency in milliseconds.
    * @param checkDevice whether to regularly check the device availability.
    */
@@ -241,7 +241,7 @@ class SerialTransport : public FileTransport {
  public:
   /**
    * Construct a new instance.
-   * @param name the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network).
+   * @param name the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network).
    * @param extraLatency the extra bus transfer latency in milliseconds.
    * @param checkDevice whether to regularly check the device availability.
    * @param speed 0 for normal speed, 1 for 4x speed, or 2 for 48x speed.
@@ -283,7 +283,7 @@ class NetworkTransport : public FileTransport {
  public:
   /**
    * Construct a new instance.
-   * @param name the device name (e.g. "/dev/ttyUSB0" for serial, "127.0.0.1:1234" for network).
+   * @param name the device name (e.g. "/dev/ttyACM0" for serial, "127.0.0.1:1234" for network).
    * @param extraLatency the extra bus transfer latency in milliseconds.
    * @param address the socket address of the device.
    * @param hostOrIp the host name or IP address of the device.

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -64,7 +64,7 @@ settings.
       --usage                give a short usage message
   -V, --version              print program version
 
-PORT is either the serial port to use (e.g. /dev/ttyUSB0) that also supports a
+PORT is either the serial port to use (e.g. /dev/ttyACM0) that also supports a
 trailing wildcard '*' for testing multiple ports, or a network port as
 "ip:port" for use with e.g. socat or ebusd-esp in PIC pass-through mode.
 ```
@@ -72,7 +72,7 @@ trailing wildcard '*' for testing multiple ports, or a network port as
 Flash firmware
 --------------
 For flashing a new firmware, you would typically do something like this:  
-`ebuspicloader -f firmware.hex /dev/ttyUSB0`
+`ebuspicloader -f firmware.hex /dev/ttyACM0`
 
 On success, the output looks similar to this:
 ```
@@ -101,7 +101,7 @@ flashing succeeded.
 Configure IP
 ------------
 Changing the IP address of an Ethernet enabled adapter, would be done like this:
-`ebuspicloader -i 192.168.1.10 -m 24 /dev/ttyUSB0`
+`ebuspicloader -i 192.168.1.10 -m 24 /dev/ttyACM0`
 
 On success, the output looks similar to this:
 ```

--- a/src/tools/ebusfeed.cpp
+++ b/src/tools/ebusfeed.cpp
@@ -44,7 +44,7 @@ using ebusd::Device;
 
 /** A structure holding all program options. */
 struct options {
-  const char* device;  //!< device to write to [/dev/ttyUSB60]
+  const char* device;  //!< device to write to [/dev/ttyACM60]
   unsigned int time;  //!< delay between bytes in us [10000]
 
   const char* dumpFile;  //!< dump file to read
@@ -52,7 +52,7 @@ struct options {
 
 /** the program options. */
 static struct options opt = {
-  "/dev/ttyUSB60",  // device
+  "/dev/ttyACM60",  // device
   10000,  // time
 
   "/tmp/ebus_dump.bin",  // dumpFile
@@ -60,7 +60,7 @@ static struct options opt = {
 
 /** the definition of the known program arguments. */
 static const ebusd::argDef argDefs[] = {
-  {"device", 'd', "DEV",     0, "Write to DEV (serial device) [/dev/ttyUSB60]"},
+  {"device", 'd', "DEV",     0, "Write to DEV (serial device) [/dev/ttyACM60]"},
   {"time",   't', "USEC",    0, "Delay each byte by USEC us [10000]"},
   {nullptr, 0x100, "DUMPFILE", af_optional, "Dump file to read [/tmp/ebus_dump.bin]"},
 
@@ -77,7 +77,7 @@ static int parse_opt(int key, char *arg, const ebusd::argParseOpt *parseOpt, str
   char* strEnd = nullptr;
   switch (key) {
   // Device settings:
-  case 'd':  // --device=/dev/ttyUSB60
+  case 'd':  // --device=/dev/ttyACM60
     if (arg == nullptr || arg[0] == 0) {
       argParseError(parseOpt, "invalid device");
       return EINVAL;
@@ -121,9 +121,9 @@ int main(int argc, char* argv[]) {
     "Example for setting up two pseudo terminals with 'socat':\n"
     "  1. 'socat -d -d pty,raw,echo=0 pty,raw,echo=0'\n"
     "  2. create symbol links to appropriate devices, e.g.\n"
-    "     'ln -s /dev/pts/2 /dev/ttyUSB60'\n"
-    "     'ln -s /dev/pts/3 /dev/ttyUSB20'\n"
-    "  3. start " PACKAGE ": '" PACKAGE " -f -d /dev/ttyUSB20 --nodevicecheck'\n"
+    "     'ln -s /dev/pts/2 /dev/ttyACM60'\n"
+    "     'ln -s /dev/pts/3 /dev/ttyACM20'\n"
+    "  3. start " PACKAGE ": '" PACKAGE " -f -d /dev/ttyACM20 --nodevicecheck'\n"
     "  4. start ebusfeed: 'ebusfeed /path/to/ebus_dump.bin'",
     nullptr,
   };

--- a/src/tools/ebuspicloader.cpp
+++ b/src/tools/ebuspicloader.cpp
@@ -1173,7 +1173,7 @@ int main(int argc, char* argv[]) {
 #ifdef __CYGWIN__
     "/dev/ttyS0 for COM1 on Windows"
 #else
-    "/dev/ttyUSB0"
+    "/dev/ttyACM0"
 #endif
     ") that also supports a trailing wildcard '*' for testing"
     " multiple ports, or a network port as \"ip:port\" for use with e.g. socat or ebusd-esp in PIC pass-through mode.",

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -9,7 +9,7 @@ $ebusd -r -f -x >/dev/null 2>/dev/null
 $ebusd -f -d "" >/dev/null 2>/dev/null
 $ebusd -f -d "tcp:192.168.999.999:1" --log bad >/dev/null 2>/dev/null
 $ebusd -f -d "enh:192.168.999.999:1" --log bad >/dev/null 2>/dev/null
-$ebusd -f -d "/dev/ttyUSBx9" --log bad >/dev/null 2>/dev/null
+$ebusd -f -d "/dev/ttyACMx9" --log bad >/dev/null 2>/dev/null
 $ebusd -f --nodevicecheck --log bad >/dev/null 2>/dev/null
 $ebusd -f --readonly >/dev/null 2>/dev/null
 $ebusd -f --scanconfig=full -r >/dev/null 2>/dev/null


### PR DESCRIPTION
Most of modern serial-to-usb devices use the CDC ACM. Device named ttyUSB are only used for devices,
which have specific drivers.

The eBSUSd documentation also talks about CDC ACM: https://adapter.ebusd.eu/v5/

This is a proposal to change it.