### PR TITLE
More conservative defaults for mqtt-hassio.cfg as some messages might not like being polled

### DIFF
--- a/contrib/etc/ebusd/mqtt-hassio.cfg
+++ b/contrib/etc/ebusd/mqtt-hassio.cfg
@@ -96,7 +96,7 @@
 # when set to 1. If set to >1, then all messages passing the other filter criteria (including active read messages) will
 # automatically be set to have a poll priority of at most this value, so these are automatically being polled.
 # HA integration: filtering only seen messages to avoid unnecessary "pollution" and auto-poll all matched messages
-filter-seen = 5
+filter-seen = 1
 # include only messages having a priority less than or equal to the specified value.
 #filter-priority =
 # include only messages having the specified circuit (partial match, alternatives and wildcard supported).

--- a/contrib/etc/ebusd/mqtt-hassio.cfg
+++ b/contrib/etc/ebusd/mqtt-hassio.cfg
@@ -96,7 +96,7 @@
 # when set to 1. If set to >1, then all messages passing the other filter criteria (including active read messages) will
 # automatically be set to have a poll priority of at most this value, so these are automatically being polled.
 # HA integration: filtering only seen messages to avoid unnecessary "pollution" and auto-poll all matched messages
-filter-seen = 1
+filter-seen = 5
 # include only messages having a priority less than or equal to the specified value.
 #filter-priority =
 # include only messages having the specified circuit (partial match, alternatives and wildcard supported).
@@ -105,7 +105,8 @@ filter-seen = 1
 #filter-non-circuit =
 # include only messages having the specified name (partial match, alternatives and wildcard supported).
 # HA integration: filter to some useful names for monitoring the heating circuit
-filter-name = status|temp|humidity|yield|count|energy|power|runtime|hours|starts|mode|curve|^load$|^party$|sensor|timer
+# NB: be careful with what you add, not all messages like to be polled!
+filter-name = ^status|^livemonitor|^testmenu|compressor|^hwc*temp
 # exclude messages having the specified name (partial match, alternatives and wildcard supported).
 #filter-non-name =
 # include only messages having the specified level (partial match, alternatives and wildcard supported).


### PR DESCRIPTION
Fixes #1205. Not seeing any issues with this and the current csvs. Maybe in the future there needs to be filter-seen-include/exclude to fine-tune automatic polling.