### PR TITLE
#1218 Improved documentation; added device class to global_uptime

### DIFF
--- a/contrib/etc/ebusd/mqtt-hassio.cfg
+++ b/contrib/etc/ebusd/mqtt-hassio.cfg
@@ -90,7 +90,8 @@
 # - "|" allows defining alternatives, e.g. "a|b" matches "but" as well as "all".
 # - "^" matches the beginning of the input, e.g. "^al" matches "al" but not "hal".
 # - "$" matches the end of the input, e.g. "al$" matches "hal" but not "all".
-# - "*" matches a single arbitrary length wildcard part in the middle, e.g. "^a*l$" matches "all" but not "always".
+# - "*" matches a single arbitrary length wildcard part in the middle, e.g. "^a*l$" matches "all" but not "always". 
+#       Only a single "*" per line is supported
 
 # include only messages having data sent at least once (only checked for passive or read messages, not for active write)
 # when set to 1. If set to >1, then all messages passing the other filter criteria (including active read messages) will
@@ -379,6 +380,7 @@ def_global_running-payload = %global_prefix,
   "device_class":"running"%global_boolean_suffix
 def_global_version-topic =
 def_global_uptime-payload = %global_prefix,
+  "device_class":"duration",
   "state_class":"total_increasing",
   "unit_of_measurement":"s"
  }

--- a/contrib/etc/ebusd/mqtt-integration.cfg
+++ b/contrib/etc/ebusd/mqtt-integration.cfg
@@ -85,6 +85,7 @@
 # - "^" matches the beginning of the input, e.g. "^al" matches "al" but not "hal".
 # - "$" matches the end of the input, e.g. "al$" matches "hal" but not "all".
 # - "*" matches a single arbitrary length wildcard part in the middle, e.g. "^a*l$" matches "all" but not "always".
+#       Only a single "*" per line is supported
 
 # include only messages having data sent at least once (only checked for passive or read messages, not for active write)
 # when set to 1. If set to >1, then all messages passing the other filter criteria (including active read messages) will


### PR DESCRIPTION
As it was not immediately obvious (at least to me) there can only be one "*" wildchar per line, I suggest to add it to the documentation.

I also propose to add 'device_class' to the global uptime topic.